### PR TITLE
Setup backend project folder, closes #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# macOS
+.DS_Store
+
+# Eclipse
+/backend/.classpath
+/backend/.project
+/backend/.settings/
+
+# Maven
+/backend/target/
+/backend/.mvn/
+

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,98 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.learn.javaweb</groupId>
+    <artifactId>jersey-hibernate-university-registry</artifactId>
+    <packaging>war</packaging>
+    <version>1.0.0</version>
+    <name>jersey-hibernate-demo</name>
+
+    <build>
+        <finalName>jersey-hibernate-university-registry</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
+                <version>${jersey.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-binding</artifactId>
+        </dependency>
+        <!-- added in addition to jersey-quickstart-webapp dependencies -->
+        <dependency>
+		    <groupId>javax.xml.bind</groupId>
+		    <artifactId>jaxb-api</artifactId>
+		    <version>2.3.0</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.glassfish.jersey.media</groupId>
+		    <artifactId>jersey-media-jaxb</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.glassfish.jaxb</groupId>
+		    <artifactId>jaxb-runtime</artifactId>
+            <version>${jersey.version}</version>
+		</dependency>
+		<dependency>
+		    <groupId>com.mysql</groupId>
+		    <artifactId>mysql-connector-j</artifactId>
+		    <version>9.3.0</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.hibernate</groupId>
+		    <artifactId>hibernate-core</artifactId>
+		    <version>5.6.15.Final</version>
+		</dependency>
+		<dependency>
+		    <groupId>net.sf.ehcache</groupId>
+		    <artifactId>ehcache</artifactId>
+		    <version>2.10.6</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.hibernate</groupId>
+		    <artifactId>hibernate-ehcache</artifactId>
+		    <version>5.6.15.Final</version>
+		</dependency>
+    </dependencies>
+    <properties>
+        <jersey.version>4.0.0-M2</jersey.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/backend/sql/init_db.sql
+++ b/backend/sql/init_db.sql
@@ -1,0 +1,31 @@
+CREATE DATABASE java_web;
+USE java_web;
+CREATE TABLE departments (
+    department_id INT AUTO_INCREMENT PRIMARY KEY,
+    department_code VARCHAR(10) NOT NULL UNIQUE,
+    department_name VARCHAR(100)
+);
+CREATE TABLE staff (
+    staff_id INT AUTO_INCREMENT PRIMARY KEY,
+    staff_code VARCHAR(20) NOT NULL UNIQUE,
+    first_name VARCHAR(100),
+    last_name VARCHAR(100),
+    role VARCHAR(50),  -- 'ADMIN', 'DIRECTOR', 'PROFESSOR', 'ASSOCIATE_PROFESSOR', 'ASSISTANT_PROFESSOR'
+    department_code VARCHAR(10),
+    FOREIGN KEY (department_code) REFERENCES departments(department_code)
+);
+CREATE TABLE admins (
+    admin_id INT AUTO_INCREMENT PRIMARY KEY,
+    staff_code VARCHAR(20) NOT NULL UNIQUE,
+    password VARCHAR(60) NOT NULL,
+    FOREIGN KEY (staff_code) REFERENCES staff(staff_code)
+);
+CREATE TABLE students (
+    student_id INT AUTO_INCREMENT PRIMARY KEY,
+    roll_number VARCHAR(20) NOT NULL UNIQUE,
+    first_name VARCHAR(100),
+    last_name VARCHAR(100),
+    joining_year SMALLINT CHECK (joining_year BETWEEN 2000 AND 3000),
+    department_code VARCHAR(10),
+    FOREIGN KEY (department_code) REFERENCES departments(department_code)
+);

--- a/backend/src/main/java/com/learn/javaweb/MyResource.java
+++ b/backend/src/main/java/com/learn/javaweb/MyResource.java
@@ -1,0 +1,25 @@
+package com.learn.javaweb;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Root resource (exposed at "myresource" path)
+ */
+@Path("myresource")
+public class MyResource {
+
+    /**
+     * Method handling HTTP GET requests. The returned object will be sent
+     * to the client as "text/plain" media type.
+     *
+     * @return String that will be returned as a text/plain response.
+     */
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getIt() {
+        return "Got it!";
+    }
+}

--- a/backend/src/main/java/hibernate.cfg.xml
+++ b/backend/src/main/java/hibernate.cfg.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+		"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+<hibernate-configuration>
+    <session-factory>
+        <property name="hibernate.connection.driver_class">com.mysql.cj.jdbc.Driver</property>
+        <property name="hibernate.connection.url">jdbc:mysql://localhost:3306/java_web</property>
+        <property name="hibernate.connection.username">root</property>
+        <property name="hibernate.dialect">org.hibernate.dialect.MySQLDialect</property>
+        <!-- update - create only if it doesn't exist -->
+        <property name="hbm2ddl.auto">update</property>
+        <property name="show_sql">true</property>
+    </session-factory>
+</hibernate-configuration>

--- a/backend/src/main/webapp/WEB-INF/web.xml
+++ b/backend/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This web.xml file is not required when using Servlet 3.0 container,
+     see implementation details http://jersey.java.net/nonav/documentation/latest/jax-rs.html -->
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+    <servlet>
+        <servlet-name>Jersey Web Application</servlet-name>
+        <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+        <init-param>
+            <param-name>jersey.config.server.provider.packages</param-name>
+            <param-value>com.learn.javaweb</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Jersey Web Application</servlet-name>
+        <url-pattern>/webapi/*</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/backend/src/main/webapp/index.jsp
+++ b/backend/src/main/webapp/index.jsp
@@ -1,0 +1,8 @@
+<html>
+<body>
+    <h2>Jersey RESTful Web Application!</h2>
+    <p><a href="webapi/myresource">Jersey resource</a>
+    <p>Visit <a href="http://jersey.java.net">Project Jersey website</a>
+    for more information on Jersey!
+</body>
+</html>


### PR DESCRIPTION
- Created a Maven project with Jersey (jersey-quickstart-webapp) and added the following to pom.xml
  - jaxb-api, jaxb-runtime, jersey-media-jaxb: Enables Jersey to convert Java objects to/from XML or JSON using JAXB
  - mysql-connector-j: Provides the JDBC driver required to connect to a MySQL database
  - hibernate-core: ORM framework that maps Java entities to relational database tables and handles data persistence
  - ehcache, hibernate-ehcache: Integrate second-level caching in Hibernate using Ehcache
- Configured Hibernate (hibernate.cfg.xml) for MySQL connection
- Created SQL script for admins, students, staff and departments tables